### PR TITLE
MRG: report correct md5sum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-branchwater"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-branchwater"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ fn write_prefetch<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
         None => Box::new(std::io::stdout()),
     };
     let mut writer = BufWriter::new(prefetch_out);
-    writeln!(&mut writer, "query_file,match,match_md5sum,overlap").ok();
+    writeln!(&mut writer, "query_file,match,match_md5,overlap").ok();
 
     for m in matchlist.iter() {
         writeln!(&mut writer, "{},\"{}\",{},{}", query_label,
@@ -490,7 +490,7 @@ fn consume_query_by_gather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display 
         None => Box::new(std::io::stdout()),
     };
     let mut writer = BufWriter::new(gather_out);
-    writeln!(&mut writer, "query_file,rank,match,match_md5sum,overlap").ok();
+    writeln!(&mut writer, "query_file,rank,match,match_md5,overlap").ok();
 
     let mut matching_sketches = matchlist;
     let mut rank = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // TODO:
-// * md5sum output by search and countergather are of modified/downsampled,
-//   not orig. This is different from sourmash...
+// @CTB: test md5sum
+// @CTB: cargo clippy/@CTB comments
 
 use pyo3::prelude::*;
 
@@ -245,7 +245,7 @@ fn manysearch<P: AsRef<Path>>(
 
                 // make sure it is compatible etc.
 
-                if !search_sm.is_some() {
+                if search_sm.is_none() {
                     eprintln!("WARNING: no compatible sketches in path '{}'",
                               filename.display());
                     let _ = skipped_paths.fetch_add(1, atomic::Ordering::SeqCst);
@@ -263,7 +263,7 @@ fn manysearch<P: AsRef<Path>>(
                         let containment = overlap / size;
                         if containment > threshold {
                             results.push((q.name.clone(),
-                                          q.minhash.md5sum(),
+                                          q.md5sum.clone(),
                                           search_sm.name.clone(),
                                           search_sm.md5sum.clone(),
                                           overlap))
@@ -358,7 +358,7 @@ fn write_prefetch<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
 
     for m in matchlist.iter() {
         writeln!(&mut writer, "{},\"{}\",{},{}", query_label,
-                 m.name, m.minhash.md5sum(), m.overlap).ok();
+                 m.name, m.md5sum, m.overlap).ok();
     }
 
     Ok(())
@@ -519,7 +519,7 @@ fn consume_query_by_gather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display 
         query.remove_from(&best_element.minhash)?;
 
         writeln!(&mut writer, "{},{},\"{}\",{},{}", query_label, rank,
-                 best_element.name, best_element.minhash.md5sum(),
+                 best_element.name, best_element.md5sum,
                  best_element.overlap).ok();
 
         // recalculate remaining overlaps between query and all sketches.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-// TODO:
-// @CTB: test md5sum
+/// Rust code for pyo3_branchwater.
 
 use pyo3::prelude::*;
 
@@ -16,7 +15,7 @@ use std::collections::BinaryHeap;
 
 use std::cmp::{PartialOrd, Ordering};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 
 #[macro_use]
 extern crate simple_error;
@@ -104,7 +103,7 @@ fn check_compatible_downsample(
 /// and a template Sketch, return a compatible (& now downsampled)
 /// Sketch from the search Signatures..
 ///
-/// @CTB note: this will return the first acceptable match, I think, ignoring
+/// CTB note: this will return the first acceptable match, I think, ignoring
 /// all others.
 
 
@@ -398,7 +397,6 @@ fn load_sketches(sketchlist_paths: Vec<PathBuf>, template: &Sketch) ->
                 sm = prepare_query(&sigs, template);
                 if sm.is_none() {
                     // track number of paths that have no matching sigs
-                    // @CTB: print error?
                     let _i = skipped_paths.fetch_add(1, atomic::Ordering::SeqCst);
                 }
             } else {
@@ -700,7 +698,6 @@ fn multigather<P: AsRef<Path> + std::fmt::Debug + Clone>(
                     if let Ok(overlap) = sm.minhash.count_common(&query.minhash, false) {
                         if overlap >= threshold_hashes {
                             let result = PrefetchResult {
-                                // CTB: use struct filling??
                                 name: sm.name.clone(),
                                 md5sum: sm.md5sum.clone(),
                                 minhash: sm.minhash.clone(),

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -45,7 +45,7 @@ def test_simple(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_file', 'match', 'match_md5sum', 'rank', 'overlap'}
+    assert keys == {'query_file', 'match', 'match_md5', 'rank', 'overlap'}
 
 
 def test_simple_with_prefetch(runtmp):
@@ -71,12 +71,12 @@ def test_simple_with_prefetch(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_file', 'match', 'match_md5sum', 'rank', 'overlap'}
+    assert keys == {'query_file', 'match', 'match_md5', 'rank', 'overlap'}
 
     df = pandas.read_csv(p_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_file', 'match', 'match_md5sum', 'overlap'}
+    assert keys == {'query_file', 'match', 'match_md5', 'overlap'}
 
 
 def test_missing_query(runtmp, capfd):
@@ -323,9 +323,9 @@ def test_md5s(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_file', 'match', 'match_md5sum', 'rank', 'overlap'}
+    assert keys == {'query_file', 'match', 'match_md5', 'rank', 'overlap'}
 
-    md5s = list(df['match_md5sum'])
+    md5s = list(df['match_md5'])
     print(md5s)
 
     for against_file in (sig2, sig47, sig63):

--- a/src/python/tests/test_multigather.py
+++ b/src/python/tests/test_multigather.py
@@ -58,12 +58,12 @@ def test_simple(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_file', 'match', 'match_md5sum', 'rank', 'overlap'}
+    assert keys == {'query_file', 'match', 'match_md5', 'rank', 'overlap'}
 
     df = pandas.read_csv(p_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_file', 'match', 'match_md5sum', 'overlap'}
+    assert keys == {'query_file', 'match', 'match_md5', 'overlap'}
 
 
 def test_missing_querylist(runtmp, capfd):
@@ -286,9 +286,9 @@ def test_md5(runtmp):
     df = pandas.read_csv(g_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_file', 'match', 'match_md5sum', 'rank', 'overlap'}
+    assert keys == {'query_file', 'match', 'match_md5', 'rank', 'overlap'}
 
-    md5s = set(df['match_md5sum'])
+    md5s = set(df['match_md5'])
     for against_file in (sig2, sig47, sig63):
         for ss in sourmash.load_file_as_signatures(against_file, ksize=31):
             assert ss.md5sum() in md5s
@@ -297,9 +297,9 @@ def test_md5(runtmp):
     df = pandas.read_csv(p_output)
     assert len(df) == 3
     keys = set(df.keys())
-    assert keys == {'query_file', 'match', 'match_md5sum', 'overlap'}
+    assert keys == {'query_file', 'match', 'match_md5', 'overlap'}
 
-    md5s = set(df['match_md5sum'])
+    md5s = set(df['match_md5'])
     for against_file in (sig2, sig47, sig63):
         for ss in sourmash.load_file_as_signatures(against_file, ksize=31):
             assert ss.md5sum() in md5s


### PR DESCRIPTION
This PR refactors `prepare_query` to incorporate common code, and also outputs the original md5sum for matches, not the downsampled one.

Fixes https://github.com/sourmash-bio/pyo3_branchwater/issues/30

Bumps version to 0.6.0

TODO:
- [x] cleanup CTB and clippy
- [x] write specific tests for md5sum
- [x] fix column names to be consistent here and with future sourmash ref https://github.com/sourmash-bio/sourmash/issues/1555
