### PR TITLE
MRG: set num threads once per test run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-branchwater"
-version = "0.6.0"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-branchwater"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/python/tests/__init__.py
+++ b/src/python/tests/__init__.py
@@ -1,0 +1,2 @@
+from pyo3_branchwater import pyo3_branchwater
+pyo3_branchwater.set_global_thread_pool(4)

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sourmash_tst_utils import TempDirectory, RunnerContext
+from .sourmash_tst_utils import TempDirectory, RunnerContext
 
 @pytest.fixture
 def runtmp():

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -3,7 +3,7 @@ import pytest
 import pandas
 
 import sourmash
-import sourmash_tst_utils as utils
+from . import sourmash_tst_utils as utils
 
 
 def get_test_data(filename):

--- a/src/python/tests/test_multigather.py
+++ b/src/python/tests/test_multigather.py
@@ -6,7 +6,7 @@ import pytest
 import pandas
 
 import sourmash
-import sourmash_tst_utils as utils
+from . import sourmash_tst_utils as utils
 
 
 def get_test_data(filename):

--- a/src/python/tests/test_search.py
+++ b/src/python/tests/test_search.py
@@ -3,7 +3,7 @@ import pytest
 import pandas
 import sourmash
 
-import sourmash_tst_utils as utils
+from . import sourmash_tst_utils as utils
 
 
 def get_test_data(filename):


### PR DESCRIPTION
This PR updates the tests so that the number of threads is set once per test run.

Explanation:
* in #57 we started using `pyo3_branchwater.set_global_thread_pool` to set the threads per user request on `-c/--cores`
* `set_global_thread_pool` can only set the number of threads once!
* in #65 I added a command line test of `sourmash scripts manysearch -c 4`
* however, if that new test wasn't the first test run, then whichever test _was_ run first would set the threads to the default, which is the max cores available
* this would then cause the new test to fail

Specifically, on my laptop, the number of cores would always get set to 8. No bueno!

This PR adds a call on test import to `set_global_thread_pool(4)`, which matches the number used in `test_search.py::test_simple_with_cores`. And the tests now pass!

Bumps version to 0.6.2.
