### PR TITLE
[MRG] allow index from a signature zipfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ log = "0.4.14"
 env_logger = "0.9.0"
 simple-error = "0.3.0"
 anyhow = "1.0.75"
+zip = "0.6"
+tempfile = "3.8"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/src/python/pyo3_branchwater/__init__.py
+++ b/src/python/pyo3_branchwater/__init__.py
@@ -177,16 +177,6 @@ class Branchwater_Index(CommandLinePlugin):
 
         notify(f"indexing all sketches in '{args.siglist}'")
 
-        sig_paths = None
-        if args.siglist.endswith('.zip'):
-            notify(f"trying to load from zip file '{args.siglist}'")
-            from sourmash.index import ZipFileLinearIndex
-            zipidx = ZipFileLinearIndex.load(args.siglist, use_manifest=True)
-            zip_path = os.path.abspath(args.siglist)
-            allfiles = zipidx.storage._filenames()
-            sig_paths = [os.path.join(zip_path, x) for x in allfiles if x.endswith('.sig') or x.endswith('.sig.gz')]
-            # get paths from zipindex; pass to pyo3_branchwater
-
         super().main(args)
         status = pyo3_branchwater.do_index(args.siglist,
                                                 args.ksize,
@@ -194,8 +184,7 @@ class Branchwater_Index(CommandLinePlugin):
                                                 args.threshold,
                                                 args.output,
                                                 args.save_paths,
-                                                False, # colors - currently must be false?
-                                                sig_paths)
+                                                False) # colors - currently must be false?
         if status == 0:
             notify(f"...index is done! results in '{args.output}'")
         return status

--- a/src/python/pyo3_branchwater/__init__.py
+++ b/src/python/pyo3_branchwater/__init__.py
@@ -167,11 +167,24 @@ class Branchwater_Index(CommandLinePlugin):
                        help='scaled factor at which to do comparisons')
         p.add_argument('--save-paths', action='store_true',
                        help='save paths to signatures into index. Default: save full sig into index')
+        p.add_argument('-c', '--cores', default=0, type=int,
+                       help='number of cores to use (default is all available)')
 
     def main(self, args):
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / threshold: {args.threshold}")
-        num_threads = pyo3_branchwater.get_num_threads()
+        num_threads = set_thread_pool(args.cores)
         notify(f"indexing all sketches in '{args.siglist}'")
+
+        sig_paths = None
+        if args.siglist.endswith('.zip'):
+            notify(f"trying to load from zip file '{args.siglist}'")
+            from sourmash.index import ZipFileLinearIndex
+            zipidx = ZipFileLinearIndex.load(args.siglist, use_manifest=True)
+            zip_path = os.path.abspath(args.siglist)
+            allfiles = zipidx.storage._filenames()
+            sig_paths = [os.path.join(zip_path, x) for x in allfiles if x.endswith('.sig') or x.endswith('.sig.gz')]
+            # get paths from zipindex; pass to pyo3_branchwater
+
         super().main(args)
         status = pyo3_branchwater.do_index(args.siglist,
                                                 args.ksize,
@@ -179,7 +192,8 @@ class Branchwater_Index(CommandLinePlugin):
                                                 args.threshold,
                                                 args.output,
                                                 args.save_paths,
-                                                False) # colors - currently must be false?
+                                                False, # colors - currently must be false?
+                                                sig_paths)
         if status == 0:
             notify(f"...index is done! results in '{args.output}'")
         return status
@@ -220,10 +234,12 @@ class Branchwater_Check(CommandLinePlugin):
 #                        help='scaled factor at which to do comparisons')
 #         p.add_argument('--save-paths', action='store_true',
 #                         help='save paths to signatures into index. Default: save full sig into index')
+#        p.add_argument('-c', '--cores', default=0, type=int,
+#                         help='number of cores to use (default is all available)')
 
 #     def main(self, args):
 #         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / threshold: {args.threshold}")
-#         num_threads = pyo3_branchwater.get_num_threads()
+#         num_threads = set_thread_pool(args.cores)
 #         notify(f"updating index with all sketches in '{args.siglist}'")
 #         super().main(args)
 #         status = pyo3_branchwater.do_update(args.siglist,
@@ -251,16 +267,18 @@ class Branchwater_Search(CommandLinePlugin):
                        help='CSV output file for matches')
         p.add_argument('-t', '--threshold-bp', default=50000, type=float,
                        help='threshold in estimated base pairs, for reporting matches (default: 50kb)')
-        p.add_argument('-c', '--containment-threshold', default=0.01, type=float,
+        p.add_argument('--containment-threshold', default=0.01, type=float,
                        help='containment threshold for reporting matches')
         p.add_argument('-k', '--ksize', default=31, type=int,
                        help='k-mer size at which to select sketches')
         p.add_argument('-s', '--scaled', default=1000, type=int,
                        help='scaled factor at which to do comparisons')
+        p.add_argument('-c', '--cores', default=0, type=int,
+                       help='number of cores to use (default is all available)')
 
     def main(self, args):
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / threshold_bp: {args.threshold_bp}")
-        num_threads = pyo3_branchwater.get_num_threads()
+        num_threads = set_thread_pool(args.cores)
         notify(f"searching all sketches in '{args.query_paths}' against '{args.index}' using {num_threads} threads")
         super().main(args)
         status = pyo3_branchwater.do_mastiffmanysearch(args.query_paths,
@@ -295,10 +313,12 @@ class Branchwater_Gather(CommandLinePlugin):
                        help='k-mer size at which to select sketches')
         p.add_argument('-s', '--scaled', default=1000, type=int,
                        help='scaled factor at which to do comparisons')
+        p.add_argument('-c', '--cores', default=0, type=int,
+                       help='number of cores to use (default is all available)')
 
     def main(self, args):
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / threshold_bp: {args.threshold_bp}")
-        num_threads = pyo3_branchwater.get_num_threads()
+        num_threads = set_thread_pool(args.cores)
         notify(f"gathering all sketches in '{args.query_paths}' against '{args.index}' using {num_threads} threads")
         super().main(args)
         status = pyo3_branchwater.do_mastiffmanygather(args.query_paths,


### PR DESCRIPTION
If I'm not mistaken, we can't yet robustly read signatures from sig `zip` files into rust. This is an experimental hackaround to extract files from zip and then pass the new filepaths into the branchwater/mastiff `index` function.

chatgpt helped me a lot with the rust, so I make no guarantees on it ... just that it seems to work for me.

indexing gtdb:
```
time sourmash scripts index gtdb-rs214-reps.k31.zip -o gtdb-rs214-reps.k31.rdb

== This is sourmash version 4.8.3. ==
== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==

ksize: 31 / scaled: 1000 / threshold: 0.01
indexing all sketches in 'gtdb-rs214-reps.k31.zip'
wrote 85205 signatures to temp dir
Loaded 85205 sig paths in siglist
...index is done! results in 'gtdb-rs214-reps.k31.rdb'

real    39m56.399s
user    33m57.385s
sys     5m51.034s
```
db is `6.7G`.

and running gather with podar-ref set:
```
time sourmash scripts gather podar-ref-list.txt /group/ctbrowngrp/sourmash-db/gtdb-
rs214/gtdb-rs214-reps.k31.rdb

== This is sourmash version 4.8.3. ==
== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==

ksize: 31 / scaled: 1000 / threshold_bp: 50000
gathering all sketches in 'podar-ref-list.txt' against '/group/ctbrowngrp/sourmash-db/gtdb-rs214/gtdb-rs214-reps.k31.rdb' using 28 threads

DONE. Processed 64 search sigs
...gather is done!

real    1m26.296s
user    1m17.609s
sys     0m7.943s
```