### PR TITLE
[MRG] abstract writer thread into reusable function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,9 +864,9 @@ trait ResultType {
 }
 
 struct SearchResult {
-    name: String,
+    query_name: String,
     query_md5: String,
-    path: String,
+    match_name: String,
     containment: f64,
     intersect_hashes: usize,
     // match_md5sum: Option<String>,
@@ -874,14 +874,14 @@ struct SearchResult {
 
 impl ResultType for SearchResult {
     fn header_fields() -> Vec<&'static str> {
-        vec!["name", "query_md5", "path", "containment", "intersect_hashes"]
+        vec!["query_name", "query_md5", "match_name", "containment", "intersect_hashes"]
     }
 
     fn format_fields(&self) -> Vec<String> {
         vec![
-            self.name.clone(),
+            format!("\"{}\"", self.query_name),  // Wrap query_name with quotes
             self.query_md5.clone(),
-            self.path.clone(),
+            format!("\"{}\"", self.match_name),  // Wrap match_name with quotes
             self.containment.to_string(),
             self.intersect_hashes.to_string(),
             //self.match_md5sum.as_ref().unwrap_or("").to_string()
@@ -991,9 +991,9 @@ fn mastiff_manysearch<P: AsRef<Path>>(
                         let containment = overlap as f64 / query_size;
                         if containment >= minimum_containment {
                             let search_result = SearchResult {
-                                name: query.name.clone(),
+                                query_name: query.name.clone(),
                                 query_md5: query.md5sum.clone(),
-                                path: path.clone(),
+                                match_name: path.clone(),
                                 containment: containment,
                                 intersect_hashes: overlap,
                             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ use sourmash::index::revindex::{RevIndex};
 use sourmash::prelude::MinHashOps;
 use sourmash::prelude::FracMinHashOps;
 
-
 /// Track a name/minhash.
 
 struct SmallSignature {
@@ -892,12 +891,12 @@ struct SearchResult {
     match_name: String,
     containment: f64,
     intersect_hashes: usize,
-    // match_md5sum: Option<String>,
+    match_md5sum: Option<String>,
 }
 
 impl ResultType for SearchResult {
     fn header_fields() -> Vec<&'static str> {
-        vec!["query_name", "query_md5", "match_name", "containment", "intersect_hashes"]
+        vec!["query_name", "query_md5", "match_name", "containment", "intersect_hashes", "match_md5"]
     }
 
     fn format_fields(&self) -> Vec<String> {
@@ -907,7 +906,10 @@ impl ResultType for SearchResult {
             format!("\"{}\"", self.match_name),  // Wrap match_name with quotes
             self.containment.to_string(),
             self.intersect_hashes.to_string(),
-            //self.match_md5sum.as_ref().unwrap_or("").to_string()
+            match &self.match_md5sum {
+                Some(md5) => md5.clone(),
+                None => "".to_string(),
+            }
         ]
     }
 }
@@ -1013,14 +1015,14 @@ fn mastiff_manysearch<P: AsRef<Path>>(
                     for (path, overlap) in matches {
                         let containment = overlap as f64 / query_size;
                         if containment >= minimum_containment {
-                            let search_result = SearchResult {
+                            results.push( SearchResult {
                                 query_name: query.name.clone(),
                                 query_md5: query.md5sum.clone(),
                                 match_name: path.clone(),
                                 containment: containment,
                                 intersect_hashes: overlap,
-                            };
-                            results.push(search_result);
+                                match_md5sum: None,
+                            });
                         }
                     }
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,12 +891,14 @@ struct SearchResult {
     match_name: String,
     containment: f64,
     intersect_hashes: usize,
-    match_md5sum: Option<String>,
+    match_md5: Option<String>,
+    jaccard: Option<f64>,
+    max_containment: Option<f64>,
 }
 
 impl ResultType for SearchResult {
     fn header_fields() -> Vec<&'static str> {
-        vec!["query_name", "query_md5", "match_name", "containment", "intersect_hashes", "match_md5"]
+        vec!["query_name", "query_md5", "match_name", "containment", "intersect_hashes", "match_md5", "jaccard", "max_containment"]
     }
 
     fn format_fields(&self) -> Vec<String> {
@@ -906,8 +908,16 @@ impl ResultType for SearchResult {
             format!("\"{}\"", self.match_name),  // Wrap match_name with quotes
             self.containment.to_string(),
             self.intersect_hashes.to_string(),
-            match &self.match_md5sum {
+            match &self.match_md5 {
                 Some(md5) => md5.clone(),
+                None => "".to_string(),
+            },
+            match &self.jaccard {
+                Some(jaccard) => jaccard.to_string(),
+                None => "".to_string(),
+            },
+            match &self.max_containment {
+                Some(max_containment) => max_containment.to_string(),
                 None => "".to_string(),
             }
         ]
@@ -1021,7 +1031,9 @@ fn mastiff_manysearch<P: AsRef<Path>>(
                                 match_name: path.clone(),
                                 containment: containment,
                                 intersect_hashes: overlap,
-                                match_md5sum: None,
+                                match_md5: None,
+                                jaccard: None,
+                                max_containment: None,
                             });
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,13 +34,6 @@ use sourmash::prelude::MinHashOps;
 use sourmash::prelude::FracMinHashOps;
 
 
-// initialize logging
-fn initialize_logger() {
-    env_logger::Builder::new()
-        .filter_level(log::LevelFilter::Info) // Set the desired log level
-        .init();
-}
-
 /// Track a name/minhash.
 
 struct SmallSignature {
@@ -1211,13 +1204,8 @@ fn do_manysearch(querylist_path: String,
                  threshold: f64,
                  ksize: u8,
                  scaled: usize,
-                 debug: bool,
                  output_path: Option<String>,
 ) -> anyhow::Result<u8> {
-    // if debug is true, initialize logger
-    if debug {
-        initialize_logger();
-    }
     // if siglist_path is revindex, run mastiff_manysearch; otherwise run manysearch
     if is_revindex_database(siglist_path.as_ref()) {
         let template = build_template(ksize, scaled);
@@ -1269,7 +1257,6 @@ fn do_multigather(query_filenames: String,
                      scaled: usize,
                      output_path: Option<String>,
 ) -> anyhow::Result<u8> {
-    initialize_logger();
     // if a siglist path is a revindex, run mastiff_manygather. If not, run multigather
     if is_revindex_database(siglist_path.as_ref()) {
         let template = build_template(ksize, scaled);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,7 +865,7 @@ trait ResultType {
 
 struct SearchResult {
     name: String,
-    query_md5sum: String,
+    query_md5: String,
     path: String,
     containment: f64,
     intersect_hashes: usize,
@@ -874,13 +874,13 @@ struct SearchResult {
 
 impl ResultType for SearchResult {
     fn header_fields() -> Vec<&'static str> {
-        vec!["name", "md5sum", "path", "containment", "intersect_hashes"]
+        vec!["name", "query_md5", "path", "containment", "intersect_hashes"]
     }
 
     fn format_fields(&self) -> Vec<String> {
         vec![
             self.name.clone(),
-            self.query_md5sum.clone(),
+            self.query_md5.clone(),
             self.path.clone(),
             self.containment.to_string(),
             self.intersect_hashes.to_string(),
@@ -992,7 +992,7 @@ fn mastiff_manysearch<P: AsRef<Path>>(
                         if containment >= minimum_containment {
                             let search_result = SearchResult {
                                 name: query.name.clone(),
-                                query_md5sum: query.md5sum.clone(),
+                                query_md5: query.md5sum.clone(),
                                 path: path.clone(),
                                 containment: containment,
                                 intersect_hashes: overlap,

--- a/src/python/pyo3_branchwater/__init__.py
+++ b/src/python/pyo3_branchwater/__init__.py
@@ -50,8 +50,6 @@ class Branchwater_Manysearch(CommandLinePlugin):
                        help='scaled factor at which to do comparisons')
         p.add_argument('-c', '--cores', default=0, type=int,
                        help='number of cores to use (default is all available)')
-        p.add_argument('--info', action='store_true',
-                       help='print debug output')
 
     def main(self, args):
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / threshold: {args.threshold}")
@@ -66,7 +64,6 @@ class Branchwater_Manysearch(CommandLinePlugin):
                                                 args.threshold,
                                                 args.ksize,
                                                 args.scaled,
-                                                args.info,
                                                 args.output)
         if status == 0:
             notify(f"...manysearch is done! results in '{args.output}'")

--- a/src/python/pyo3_branchwater/__init__.py
+++ b/src/python/pyo3_branchwater/__init__.py
@@ -50,6 +50,8 @@ class Branchwater_Manysearch(CommandLinePlugin):
                        help='scaled factor at which to do comparisons')
         p.add_argument('-c', '--cores', default=0, type=int,
                        help='number of cores to use (default is all available)')
+        p.add_argument('--info', action='store_true',
+                       help='print debug output')
 
     def main(self, args):
         notify(f"ksize: {args.ksize} / scaled: {args.scaled} / threshold: {args.threshold}")
@@ -64,6 +66,7 @@ class Branchwater_Manysearch(CommandLinePlugin):
                                                 args.threshold,
                                                 args.ksize,
                                                 args.scaled,
+                                                args.info,
                                                 args.output)
         if status == 0:
             notify(f"...manysearch is done! results in '{args.output}'")


### PR DESCRIPTION
Since we reuse the multithreading code in each function (and I wanted to understand it better), this PR abstracts the writer thread into a reusable function and uses it in both `manysearch` and `mastiff_manysearch`.

Ideally, we could reuse this for all functions (gather, etc) -- but, I wanted a review to see if this went in the right direction.

Since this change means that we need to pass a consistent object to the writer, this PR also creates a `SearchResult` struct (and associated methods) that is created during each 'search' loop and passed to the writer thread. 

For gather (a later PR if we want to go this route), Luiz already has a GatherResult in the works (https://github.com/sourmash-bio/sourmash/blob/ba581ea8c6f046b7e19da274155f326d2bdbc8e7/src/core/src/index/revindex.rs#L572), so it's possible we could import from there. But defining a simple one here while things are still in flux may be the easier option, since I want it to have these formatting options for easy printing...
