### PR TITLE
MRG: rename rust functions to match CLI.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -26,35 +26,13 @@ find gtdb-reps-rs214-k21/ -name "*.sig.gz" -type f > list.gtdb-reps-rs214-k21.tx
 
 ## Running the commands
 
-### Running `manysearch`
-
-The `manysearch` command finds overlaps between one or more query genomes, and one or more subject (meta)genomes. It is the core command we use for searching petabase-scale databases.
-
-`manysearch` takes two file lists as input, and outputs a CSV:
-```
-sourmash scripts manysearch query-list.txt podar-ref-list.txt -o results.csv
-```
-
-To run it, you need to provide two "fromfiles" containing lists of paths to signature files (`.sig` or `.sig.gz`). If you create a fromfile as above with GTDB reps, you can generate a query fromfile like so:
-
-```
-head -10 list.gtdb-reps-rs214-k21.txt > list.query.txt
-```
-and then run `manysearch` like so:
-
-```
-sourmash scripts manysearch list.query.txt list.gtdb-rs214-k21.txt  -o query.x.gtdb-reps.csv -k 21 --cores 4
-```
-
-The results file here, `query.x.gtdb-reps.csv`, will have 8 columns: `query` and `query_md5`, `match` and `match_md5`, and `containment`, `jaccard`, `max_containment`, and `intersect_hashes`.
-
 ### Running `multisearch`
 
 The `multisearch` command compares one or more query genomes, and one or more subject genomes. It differs from `manysearch` by loading everything into memory.
 
-`manysearch` takes two file lists as input, and outputs a CSV:
+`multisearch` takes two file lists as input, and outputs a CSV:
 ```
-sourmash scripts manysearch query-list.txt podar-ref-list.txt -o results.csv
+sourmash scripts multisearch query-list.txt podar-ref-list.txt -o results.csv
 ```
 
 To run it, you need to provide two "fromfiles" containing lists of paths to signature files (`.sig` or `.sig.gz`). If you create a fromfile as above with GTDB reps, you can generate a query fromfile like so:
@@ -62,17 +40,17 @@ To run it, you need to provide two "fromfiles" containing lists of paths to sign
 ```
 head -10 list.gtdb-reps-rs214-k21.txt > list.query.txt
 ```
-and then run `manysearch` like so:
+and then run `multisearch` like so:
 
 ```
-sourmash scripts manysearch list.query.txt list.gtdb-rs214-k21.txt  -o query.x.gtdb-reps.csv -k 21 --cores 4
+sourmash scripts multisearch list.query.txt list.gtdb-rs214-k21.txt  -o query.x.gtdb-reps.csv -k 21 --cores 4
 ```
 
 The results file here, `query.x.gtdb-reps.csv`, will have 8 columns: `query` and `query_md5`, `match` and `match_md5`, and `containment`, `jaccard`, `max_containment`, and `intersect_hashes`.
 
 ### Running `fastgather`
 
-The `fastgather` command is a much faster version of `sourmash gather``.
+The `fastgather` command is a much faster version of `sourmash gather`.
 
 `fastgather` takes a query metagenome and a file list as the database, and outputs a CSV:
 ```
@@ -111,7 +89,7 @@ A complete example Snakefile implementing the above workflow is available [in th
 sourmash scripts fastmultigather query-list.txt podar-ref-lists.txt --cores 4
 ```
 
-The main advantage that `fastmultigather` has over `fastgather` is that you only load the database files once, which can be a significant time savings for large databases!
+The main advantage that `fastmultigather` has over running `fastgather` on multiple queries is that you only load the database files once, which can be a significant time savings for large databases!
 
 #### Output files for `fastmultigather`
 
@@ -120,6 +98,28 @@ The main advantage that `fastmultigather` has over `fastgather` is that you only
 The prefetch CSV will be named `{basename}.prefetch.csv`, and the gather CSV will be named `{basename}.gather.csv`.  Here, `{basename}` is the filename, stripped of its path.
 
 **Warning:** At the moment, if two different queries have the same `{basename}`, the CSVs for one of the queries will be overwritten by the other query. The behavior here is undefined in practice, because of multithreading: we don't know what queries will be executed when or files will be written first.
+
+### Running `manysearch`
+
+The `manysearch` command compares one or more query sketches, and one or more subject sketches. It is the core command we use for searching petabase-scale databases of metagenomes for contained genomes.
+
+`manysearch` takes two file lists as input, and outputs a CSV:
+```
+sourmash scripts manysearch query-list.txt podar-ref-list.txt -o results.csv
+```
+
+To run it, you need to provide two "fromfiles" containing lists of paths to signature files (`.sig` or `.sig.gz`). If you create a fromfile as above with GTDB reps, you can generate a query fromfile like so:
+
+```
+head -10 list.gtdb-reps-rs214-k21.txt > list.query.txt
+```
+and then run `manysearch` like so:
+
+```
+sourmash scripts manysearch list.query.txt list.gtdb-rs214-k21.txt  -o query.x.gtdb-reps.csv -k 21 --cores 4
+```
+
+The results file here, `query.x.gtdb-reps.csv`, will have 8 columns: `query` and `query_md5`, `match` and `match_md5`, and `containment`, `jaccard`, `max_containment`, and `intersect_hashes`.
 
 ## Notes on concurrency and efficiency
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,7 +526,7 @@ fn consume_query_by_gather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display 
 
 /// Run counter-gather with a query against a list of files.
 
-fn countergather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
+fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     query_filename: P,
     matchlist_filename: P,
     threshold_bp: usize,
@@ -612,7 +612,7 @@ fn countergather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
 
 /// Run counter-gather for multiple queries against a list of files.
 
-fn multigather<P: AsRef<Path> + std::fmt::Debug + Clone>(
+fn fastmultigather<P: AsRef<Path> + std::fmt::Debug + Clone>(
     query_filenames: P,
     matchlist_filename: P,
     threshold_bp: usize,
@@ -1395,7 +1395,7 @@ fn do_manysearch(querylist_path: String,
 }
 
 #[pyfunction]
-fn do_countergather(query_filename: String,
+fn do_fastgather(query_filename: String,
                     siglist_path: String,
                     threshold_bp: usize,
                     ksize: u8,
@@ -1403,7 +1403,7 @@ fn do_countergather(query_filename: String,
                     output_path_prefetch: Option<String>,
                     output_path_gather: Option<String>,
 ) -> anyhow::Result<u8> {
-    match countergather(query_filename, siglist_path, threshold_bp,
+    match fastgather(query_filename, siglist_path, threshold_bp,
                         ksize, scaled,
                         output_path_prefetch,
                         output_path_gather) {
@@ -1416,7 +1416,7 @@ fn do_countergather(query_filename: String,
 }
 
 #[pyfunction]
-fn do_multigather(query_filenames: String,
+fn do_fastmultigather(query_filenames: String,
                      siglist_path: String,
                      threshold_bp: usize,
                      ksize: u8,
@@ -1434,7 +1434,7 @@ fn do_multigather(query_filenames: String,
             }
         }
     } else {
-        match multigather(query_filenames, siglist_path, threshold_bp, ksize, scaled) {
+        match fastmultigather(query_filenames, siglist_path, threshold_bp, ksize, scaled) {
             Ok(_) => Ok(0),
             Err(e) => {
                 eprintln!("Error: {e}");
@@ -1510,8 +1510,8 @@ fn do_multisearch(querylist_path: String,
 #[pymodule]
 fn pyo3_branchwater(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_manysearch, m)?)?;
-    m.add_function(wrap_pyfunction!(do_countergather, m)?)?;
-    m.add_function(wrap_pyfunction!(do_multigather, m)?)?;
+    m.add_function(wrap_pyfunction!(do_fastgather, m)?)?;
+    m.add_function(wrap_pyfunction!(do_fastmultigather, m)?)?;
     m.add_function(wrap_pyfunction!(do_index, m)?)?;
     m.add_function(wrap_pyfunction!(do_check, m)?)?;
     m.add_function(wrap_pyfunction!(set_global_thread_pool, m)?)?;

--- a/src/python/pyo3_branchwater/__init__.py
+++ b/src/python/pyo3_branchwater/__init__.py
@@ -109,13 +109,13 @@ class Branchwater_Fastgather(CommandLinePlugin):
 
         notify(f"gathering all sketches in '{args.query_sig}' against '{args.against_paths}' using {num_threads} threads")
         super().main(args)
-        status = pyo3_branchwater.do_countergather(args.query_sig,
-                                                   args.against_paths,
-                                                   int(args.threshold_bp),
-                                                   args.ksize,
-                                                   args.scaled,
-                                                   args.output_gather,
-                                                   args.output_prefetch)
+        status = pyo3_branchwater.do_fastgather(args.query_sig,
+                                                args.against_paths,
+                                                int(args.threshold_bp),
+                                                args.ksize,
+                                                args.scaled,
+                                                args.output_gather,
+                                                args.output_prefetch)
         if status == 0:
             notify(f"...fastgather is done! gather results in '{args.output_gather}'")
             if args.output_prefetch:
@@ -151,12 +151,12 @@ class Branchwater_Fastmultigather(CommandLinePlugin):
 
         notify(f"gathering all sketches in '{args.query_paths}' against '{args.against_paths}' using {num_threads} threads")
         super().main(args)
-        status = pyo3_branchwater.do_multigather(args.query_paths,
-                                                 args.against_paths,
-                                                 int(args.threshold_bp),
-                                                 args.ksize,
-                                                 args.scaled,
-                                                 args.output)
+        status = pyo3_branchwater.do_fastmultigather(args.query_paths,
+                                                     args.against_paths,
+                                                     int(args.threshold_bp),
+                                                     args.ksize,
+                                                     args.scaled,
+                                                     args.output)
         if status == 0:
             notify(f"...fastmultigather is done!")
         return status
@@ -249,11 +249,11 @@ class Branchwater_Multisearch(CommandLinePlugin):
 
         super().main(args)
         status = pyo3_branchwater.do_multisearch(args.query_paths,
-                                                args.against_paths,
-                                                args.threshold,
-                                                args.ksize,
-                                                args.scaled,
-                                                args.output)
+                                                 args.against_paths,
+                                                 args.threshold,
+                                                 args.ksize,
+                                                 args.scaled,
+                                                 args.output)
         if status == 0:
             notify(f"...multisearch is done! results in '{args.output}'")
         return status


### PR DESCRIPTION
Fixes #67 

contains leftovers from https://github.com/sourmash-bio/pyo3_branchwater/pull/89 too.