### PR TITLE
MRG: add utility functions for zip reading; use in index, multisearch

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -13,7 +13,7 @@ pub fn index<P: AsRef<Path>>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("Loading siglist");
 
-    let (index_sigs, temp_dir) = load_sigpaths_from_zip_or_pathlist(&siglist)?;
+    let (index_sigs, _temp_dir) = load_sigpaths_from_zip_or_pathlist(&siglist)?;
 
     // if index_sigs pathlist is empty, bail
     if index_sigs.is_empty() {

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,9 +1,8 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use sourmash::sketch::Sketch;
 use sourmash::index::revindex::RevIndex;
 
-
-use crate::utils::{read_signatures_from_zip, load_sketchlist_filenames};
+use crate::utils::load_sigpaths_from_zip_or_pathlist;
 
 pub fn index<P: AsRef<Path>>(
     siglist: P,
@@ -12,35 +11,20 @@ pub fn index<P: AsRef<Path>>(
     save_paths: bool,
     colors: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut temp_dir = None;
     println!("Loading siglist");
 
-    let index_sigs: Vec<PathBuf>;
-
-    if siglist.as_ref().extension().map(|ext| ext == "zip").unwrap_or(false) {
-        let (paths, tempdir) = read_signatures_from_zip(&siglist)?;
-        temp_dir = Some(tempdir);
-        index_sigs = paths;
-    } else {
-        index_sigs = load_sketchlist_filenames(&siglist)?;
-    }
+    let (index_sigs, temp_dir) = load_sigpaths_from_zip_or_pathlist(&siglist)?;
 
     // if index_sigs pathlist is empty, bail
     if index_sigs.is_empty() {
         bail!("No signatures to index loaded, exiting.");
     }
 
-    eprintln!("Loaded {} sig paths in siglist", index_sigs.len());
-
     // Create or open the RevIndex database with the provided output path and colors flag
     let db = RevIndex::create(output.as_ref(), colors);
 
     // Index the signatures using the loaded template, threshold, and save_paths option
     db.index(index_sigs, &template, 0.0, save_paths);
-
-    if let Some(temp_dir) = temp_dir {
-        temp_dir.close()?;
-    }
 
     Ok(())
 }

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 
 use std::io::Read;
 use std::path::Path;
-use crate::utils::{Params, load_sketch_fromfile, ZipMessage, sigwriter};
+use crate::utils::{Params, load_fasta_fromfile, ZipMessage, sigwriter};
 use sourmash::signature::Signature;
 use sourmash::cmd::ComputeParameters;
 use std::sync::atomic;
@@ -130,7 +130,7 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
     output: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
 
-    let fileinfo = match load_sketch_fromfile(&filelist) {
+    let fileinfo = match load_fasta_fromfile(&filelist) {
         Ok(result) => result,
         Err(e) => bail!("Could not load fromfile csv. Underlying error: {}", e)
     };

--- a/src/python/tests/test_index.py
+++ b/src/python/tests/test_index.py
@@ -151,7 +151,7 @@ def test_index_zipfile(runtmp, capfd):
     assert 'index is done' in runtmp.last_result.err
     captured = capfd.readouterr()
     print(captured.err)
-    assert 'Loaded 3 sig paths in siglist' in captured.err
+    assert 'Found 3 filepaths' in captured.err
 
 
 def test_index_check(runtmp):

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -409,8 +409,8 @@ pub fn load_sketches_from_zip<P: AsRef<Path>>(
     let mut sketchlist = Vec::new();
     let zip_file = File::open(&zip_path)?;
     let mut zip_archive = ZipArchive::new(zip_file)?;
-    let skipped_paths = AtomicUsize::new(0);
-    let failed_paths = AtomicUsize::new(0);
+    let mut skipped_paths = 0;
+    let mut failed_paths = 0;
 
     // loop through, loading signatures
     for i in 0..zip_archive.len() {
@@ -425,17 +425,17 @@ pub fn load_sketches_from_zip<P: AsRef<Path>>(
                 sketchlist.push(sm);
             } else {
                 // track number of paths that have no matching sigs
-                skipped_paths.fetch_add(1, atomic::Ordering::SeqCst);
+                skipped_paths += 1;
             }
         } else {
             // failed to load from this path - print error & track.
             eprintln!("WARNING: could not load sketches from path '{}'", file_name);
-            failed_paths.fetch_add(1, atomic::Ordering::SeqCst);
+            failed_paths += 1;
         }
     }
     drop(zip_archive);
     println!("loaded {} signatures", sketchlist.len());
-    Ok((sketchlist, skipped_paths.load(atomic::Ordering::SeqCst), failed_paths.load(atomic::Ordering::SeqCst)))
+    Ok((sketchlist, skipped_paths, failed_paths))
 }
 
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,6 +25,7 @@ use sourmash::sketch::Sketch;
 use sourmash::prelude::MinHashOps;
 use sourmash::prelude::FracMinHashOps;
 
+// use tempfile::tempdir;
 /// Track a name/minhash.
 
 pub struct SmallSignature {
@@ -171,7 +172,6 @@ pub fn prefetch(
 }
 
 /// Write list of prefetch matches.
-
 pub fn write_prefetch<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     query: &SmallSignature,
     prefetch_output: Option<P>,
@@ -195,7 +195,6 @@ pub fn write_prefetch<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clo
 }
 
 /// Load a list of filenames from a file. Exits on bad lines.
-
 pub fn load_sketchlist_filenames<P: AsRef<Path>>(sketchlist_filename: &P) ->
     Result<Vec<PathBuf>>
 {
@@ -221,7 +220,34 @@ pub fn load_sketchlist_filenames<P: AsRef<Path>>(sketchlist_filename: &P) ->
     Ok(sketchlist_filenames)
 }
 
-pub fn load_sketch_fromfile<P: AsRef<Path>>(sketchlist_filename: &P) -> Result<Vec<(String, PathBuf, String)>> {
+
+pub fn load_sigpaths_from_zip<P: AsRef<Path>>(
+    zip_path: P,
+) -> Result<(Vec<PathBuf>, tempfile::TempDir)> {
+    let mut signature_paths = Vec::new();
+    let temp_dir = tempdir()?;
+    let zip_file = File::open(&zip_path)?;
+    let mut zip_archive = ZipArchive::new(zip_file)?;
+
+    for i in 0..zip_archive.len() {
+        let mut file = zip_archive.by_index(i)?;
+        let mut sig = Vec::new();
+        file.read_to_end(&mut sig)?;
+
+        let file_name = Path::new(file.name()).file_name().unwrap().to_str().unwrap();
+        if file_name.ends_with(".sig") || file_name.ends_with(".sig.gz") {
+            let mut new_file = File::create(temp_dir.path().join(file_name))?;
+            new_file.write_all(&sig)?;
+
+            // add path to signature_paths
+            signature_paths.push(temp_dir.path().join(file_name));
+        }
+    }
+    println!("loaded paths for {} signature files from zipfile {}", signature_paths.len(), zip_path.as_ref().display());
+    Ok((signature_paths, temp_dir))
+}
+
+pub fn load_fasta_fromfile<P: AsRef<Path>>(sketchlist_filename: &P) -> Result<Vec<(String, PathBuf, String)>> {
     let mut rdr = csv::Reader::from_path(sketchlist_filename)?;
 
     // Check for right header
@@ -375,6 +401,127 @@ pub fn load_sketches_above_threshold(
     Ok((matchlist, skipped_paths, failed_paths))
 }
 
+
+pub fn load_sketches_from_zip<P: AsRef<Path>>(
+    zip_path: P,
+    template: &Sketch,
+) -> Result<(Vec<SmallSignature>, usize, usize)> {
+    let mut sketchlist = Vec::new();
+    let zip_file = File::open(&zip_path)?;
+    let mut zip_archive = ZipArchive::new(zip_file)?;
+    let skipped_paths = AtomicUsize::new(0);
+    let failed_paths = AtomicUsize::new(0);
+
+    // loop through, loading signatures
+    for i in 0..zip_archive.len() {
+        let mut file = zip_archive.by_index(i)?;
+        let file_name = Path::new(file.name()).file_name().unwrap().to_str().unwrap().to_owned();
+
+        if !file_name.ends_with(".sig") && !file_name.ends_with(".sig.gz") {
+            continue;
+        }
+        if let Ok(sigs) = Signature::from_reader(&mut file) {
+            if let Some(sm) = prepare_query(&sigs, template, &zip_path.as_ref().display().to_string()) {
+                sketchlist.push(sm);
+            } else {
+                // track number of paths that have no matching sigs
+                skipped_paths.fetch_add(1, atomic::Ordering::SeqCst);
+            }
+        } else {
+            // failed to load from this path - print error & track.
+            eprintln!("WARNING: could not load sketches from path '{}'", file_name);
+            failed_paths.fetch_add(1, atomic::Ordering::SeqCst);
+        }
+    }
+    drop(zip_archive);
+    println!("loaded {} signatures", sketchlist.len());
+    Ok((sketchlist, skipped_paths.load(atomic::Ordering::SeqCst), failed_paths.load(atomic::Ordering::SeqCst)))
+}
+
+
+pub fn load_sigpaths_from_zip_or_pathlist<P: AsRef<Path>>(
+    sketchlist_path: P,
+) -> Result<(Vec<PathBuf>, Option<tempfile::TempDir>)> {
+    eprintln!("Reading list of filepaths from: '{}'", sketchlist_path.as_ref().display());
+
+    let result = if sketchlist_path.as_ref().extension().map(|ext| ext == "zip").unwrap_or(false) {
+        let (paths, tempdir) = load_sigpaths_from_zip(&sketchlist_path)?;
+        (paths, Some(tempdir))
+    } else {
+        let paths = load_sketchlist_filenames(&sketchlist_path)?;
+        (paths, None)
+    };
+
+    eprintln!("Found {} filepaths", result.0.len());
+    // should we bail here if empty?
+    Ok(result)
+}
+
+pub enum ReportType {
+    Query,
+    Against,
+}
+
+impl std::fmt::Display for ReportType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let description = match self {
+            ReportType::Query => "query",
+            ReportType::Against => "search",
+        };
+        write!(f, "{}", description)
+    }
+}
+
+pub fn load_sketches_from_zip_or_pathlist<P: AsRef<Path>>(
+    sketchlist_path: P,
+    template: &Sketch,
+    report_type: ReportType,
+) -> Result<Vec<SmallSignature>> {
+    eprintln!("Reading list of {} paths from: '{}'", report_type, sketchlist_path.as_ref().display());
+
+    let (sketchlist, skipped_paths, failed_paths) =
+        if sketchlist_path.as_ref().extension().map(|ext| ext == "zip").unwrap_or(false) {
+            load_sketches_from_zip(sketchlist_path, template)?
+        } else {
+            let sketch_paths = load_sketchlist_filenames(&sketchlist_path)?;
+            load_sketches(sketch_paths, template)?
+        };
+
+    report_on_sketch_loading(&sketchlist, skipped_paths, failed_paths, report_type)?;
+
+    Ok(sketchlist)
+}
+
+pub fn report_on_sketch_loading(
+    sketchlist: &[SmallSignature],
+    skipped_paths: usize,
+    failed_paths: usize,
+    report_type: ReportType,
+) -> Result<()> {
+
+    if failed_paths > 0 {
+        eprintln!(
+            "WARNING: {} {} paths failed to load. See error messages above.",
+            failed_paths,
+            report_type
+        );
+    }
+    if skipped_paths > 0 {
+        eprintln!(
+            "WARNING: skipped {} {} paths - no compatible signatures.",
+            skipped_paths,
+            report_type
+        );
+    }
+
+    // Validate sketches
+    eprintln!("Loaded {} {} signature(s)", sketchlist.len(), report_type);
+    if sketchlist.is_empty() {
+        bail!("No {} signatures loaded, exiting.", report_type);
+    }
+    Ok(())
+}
+
 /// Execute the gather algorithm, greedy min-set-cov, by iteratively
 /// removing matches in 'matchlist' from 'query'.
 
@@ -434,8 +581,6 @@ pub fn consume_query_by_gather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Disp
 }
   
 
-  // mastiff rocksdb functions
-
 pub fn build_template(ksize: u8, scaled: usize) -> Sketch {
     let max_hash = max_hash_for_scaled(scaled as u64);
     let template_mh = KmerMinHash::builder()
@@ -446,32 +591,6 @@ pub fn build_template(ksize: u8, scaled: usize) -> Sketch {
     Sketch::MinHash(template_mh)
 }
 
-pub fn read_signatures_from_zip<P: AsRef<Path>>(
-    zip_path: P,
-) -> Result<(Vec<PathBuf>, tempfile::TempDir), Box<dyn std::error::Error>> {
-    let mut signature_paths = Vec::new();
-    let temp_dir = tempdir()?;
-    let zip_file = File::open(&zip_path)?;
-    let mut zip_archive = ZipArchive::new(zip_file)?;
-
-    for i in 0..zip_archive.len() {
-        let mut file = zip_archive.by_index(i)?;
-        let mut sig = Vec::new();
-        file.read_to_end(&mut sig)?;
-
-        let file_name = Path::new(file.name()).file_name().unwrap().to_str().unwrap();
-        if file_name.ends_with(".sig") || file_name.ends_with(".sig.gz") {
-            println!("Found signature file: {}", file_name);
-            let mut new_file = File::create(temp_dir.path().join(file_name))?;
-            new_file.write_all(&sig)?;
-
-            // Push the created path directly to the vector
-            signature_paths.push(temp_dir.path().join(file_name));
-        }
-    }
-    println!("wrote {} signatures to temp dir", signature_paths.len());
-    Ok((signature_paths, temp_dir))
-}
 
 pub fn is_revindex_database(path: &Path) -> bool {
     // quick file check for Revindex database:


### PR DESCRIPTION
Extracted from #99, because all the changes were getting unruly.

This should be easier to review - contains the functions & modifications to use them in `index` and `multisearch`, with tests.

New in `utils.py`:
- load_sigpaths_from_zip_or_pathlist
- load_sketches_from_zip_or_pathlist
- report_on_sketch_loading (unifies signature loading reporting)

Renamed:
- `read_signatures_from_zip` --> `load_sketches_from_zip`
- `load_sketch_fromfile` --> `load_fasta_fromfile`

Note: In the case of reading a pathlist from a zip file, this means we extract the sig files and store them in a temp directory which will be deleted when it goes out of scope. This adds a little overhead, but I think it could worth it for the simplicity of being able to specify a zip database. Open to removing, though.
