### PR TITLE
MRG: add zip loading for `fastgather`

### DIFF
--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -8,7 +8,8 @@ use sourmash::sketch::minhash::{max_hash_for_scaled, KmerMinHash};
 use sourmash::sketch::Sketch;
 
 use crate::utils::{prepare_query, write_prefetch,
-    load_sketchlist_filenames, load_sketches_above_threshold, consume_query_by_gather};
+    load_sketches_above_threshold, consume_query_by_gather,
+    load_sigpaths_from_zip_or_pathlist};
 
 pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     query_filename: P,
@@ -44,7 +45,8 @@ pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     // build the list of paths to match against.
     eprintln!("Loading matchlist from '{}'", matchlist_filename.as_ref().display());
 
-    let matchlist_paths = load_sketchlist_filenames(&matchlist_filename)?;
+    let matchlist_filename = matchlist_filename.as_ref().to_string_lossy().to_string();
+    let (matchlist_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(&matchlist_filename)?;
 
     eprintln!("Loaded {} sig paths in matchlist", matchlist_paths.len());
 
@@ -71,16 +73,16 @@ pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     let failed_paths = result.2;
 
     if skipped_paths > 0 {
-        eprintln!("WARNING: skipped {} paths - no compatible signatures.",
+        eprintln!("WARNING: skipped {} search paths - no compatible signatures.",
                   skipped_paths);
     }
     if failed_paths > 0 {
-        eprintln!("WARNING: {} signature paths failed to load. See error messages above.",
+        eprintln!("WARNING: {} search paths failed to load. See error messages above.",
                   failed_paths);
     }
 
     if matchlist.is_empty() {
-        eprintln!("No matchlist signatures loaded, exiting.");
+        eprintln!("No search signatures loaded, exiting.");
         return Ok(());
     }
 

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -197,7 +197,7 @@ def test_bad_against_2(runtmp, capfd):
     print(captured.err)
 
     assert "WARNING: could not load sketches from path 'no-exist'" in captured.err
-    assert "WARNING: 1 signature paths failed to load. See error messages above." in captured.err
+    assert "WARNING: 1 search paths failed to load. See error messages above." in captured.err
 
 
 def test_bad_against_3(runtmp, capfd):
@@ -225,7 +225,7 @@ def test_bad_against_3(runtmp, capfd):
     assert "Sketch loading error: File is too short, less than five bytes" in captured.err
     assert "WARNING: could not load sketches from path" in captured.err
 
-    assert "WARNING: 1 signature paths failed to load. See error messages above." in captured.err
+    assert "WARNING: 1 search paths failed to load. See error messages above." in captured.err
 
 
 def test_against_multisigfile(runtmp):
@@ -298,7 +298,7 @@ def test_against_nomatch(runtmp, capfd):
     captured = capfd.readouterr()
     print(captured.err)
 
-    assert 'WARNING: skipped 1 paths - no compatible signatures.' in captured.err
+    assert 'WARNING: skipped 1 search paths - no compatible signatures.' in captured.err
 
 
 def test_md5s(runtmp):

--- a/src/python/tests/test_gather.py
+++ b/src/python/tests/test_gather.py
@@ -17,6 +17,12 @@ def make_file_list(filename, paths):
         fp.write("\n")
 
 
+def zip_siglist(runtmp, siglist, db):
+    runtmp.sourmash('sig', 'cat', siglist,
+                    '-o', db)
+    return db
+
+
 def test_installed(runtmp):
     with pytest.raises(utils.SourmashCommandFailed):
         runtmp.sourmash('scripts', 'fastgather')
@@ -24,7 +30,8 @@ def test_installed(runtmp):
     assert 'usage:  fastgather' in runtmp.last_result.err
 
 
-def test_simple(runtmp):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_simple(runtmp, zip_against):
     # test basic execution!
     query = get_test_data('SRR606249.sig.gz')
     against_list = runtmp.output('against.txt')
@@ -34,6 +41,9 @@ def test_simple(runtmp):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -48,7 +58,9 @@ def test_simple(runtmp):
     assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'rank', 'intersect_bp'}
 
 
-def test_simple_with_prefetch(runtmp):
+
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_simple_with_prefetch(runtmp, zip_against):
     # test basic execution!
     query = get_test_data('SRR606249.sig.gz')
     against_list = runtmp.output('against.txt')
@@ -58,6 +70,9 @@ def test_simple_with_prefetch(runtmp):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -79,7 +94,8 @@ def test_simple_with_prefetch(runtmp):
     assert keys == {'query_filename', 'query_name', 'query_md5', 'match_name', 'match_md5', 'intersect_bp'}
 
 
-def test_missing_query(runtmp, capfd):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_missing_query(runtmp, capfd, zip_against):
     # test missing query
     query = runtmp.output('no-such-file')
     against_list = runtmp.output('against.txt')
@@ -89,6 +105,9 @@ def test_missing_query(runtmp, capfd):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -103,8 +122,8 @@ def test_missing_query(runtmp, capfd):
 
     assert 'Error: No such file or directory ' in captured.err
 
-
-def test_bad_query(runtmp, capfd):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_bad_query(runtmp, capfd, zip_against):
     # test non-sig query
     query = runtmp.output('no-such-file')
     against_list = runtmp.output('against.txt')
@@ -117,6 +136,9 @@ def test_bad_query(runtmp, capfd):
     make_file_list(query, [sig2])
 
     make_file_list(against_list, [sig2, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -132,7 +154,8 @@ def test_bad_query(runtmp, capfd):
     assert 'Error: expected value at line 1' in captured.err
 
 
-def test_missing_against(runtmp, capfd):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_missing_against(runtmp, capfd, zip_against):
     # test missing against
     query = get_test_data('SRR606249.sig.gz')
     against_list = runtmp.output('against.txt')
@@ -142,6 +165,8 @@ def test_missing_against(runtmp, capfd):
     sig63 = get_test_data('63.fa.sig.gz')
 
     #make_file_list(against_list, [sig2, sig47, sig63])
+    if zip_against:
+        against_list = runtmp.output('against.zip')
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -228,7 +253,33 @@ def test_bad_against_3(runtmp, capfd):
     assert "WARNING: 1 search paths failed to load. See error messages above." in captured.err
 
 
-def test_against_multisigfile(runtmp):
+def test_bad_against_4(runtmp, capfd):
+    # test with a bad against (a .sig.gz file renamed as zip file)
+    query = get_test_data('SRR606249.sig.gz')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    against_zip = runtmp.output('against.zip')
+    # cp sig2 into against_zip
+    with open(against_zip, 'wb') as fp:
+        with open(sig2, 'rb') as fp2:
+            fp.write(fp2.read())
+
+    g_output = runtmp.output('gather.csv')
+    p_output = runtmp.output('prefetch.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'fastgather', query, against_zip,
+                    '-o', g_output, '--output-prefetch', p_output,
+                    '-s', '100000')
+
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert 'Error: invalid Zip archive: Could not find central directory end' in captured.err
+
+
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_against_multisigfile(runtmp, zip_against):
     # test against a sigfile that contains multiple sketches
     query = get_test_data('SRR606249.sig.gz')
     against_list = runtmp.output('against.txt')
@@ -241,6 +292,9 @@ def test_against_multisigfile(runtmp):
     runtmp.sourmash('sig', 'cat', sig2, sig47, sig63, '-o', combined)
     make_file_list(against_list, [combined])
 
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
+
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
 
@@ -248,11 +302,15 @@ def test_against_multisigfile(runtmp):
                     '-o', g_output, '--output-prefetch', p_output,
                     '-s', '100000')
     df = pandas.read_csv(g_output)
-    assert len(df) == 1
+    if zip_against:
+        assert len(df) == 3
+    else:
+        assert len(df) == 1
     # @CTB this is a bug :(. It should load multiple sketches properly!
 
 
-def test_query_multisigfile(runtmp):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_query_multisigfile(runtmp, zip_against):
     # test with a sigfile that contains multiple sketches
     against_list = runtmp.output('against.txt')
 
@@ -265,6 +323,9 @@ def test_query_multisigfile(runtmp):
 
     make_file_list(against_list, [sig2, sig47, sig63])
 
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
+
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
 
@@ -276,7 +337,8 @@ def test_query_multisigfile(runtmp):
     assert len(df) == 1
 
 
-def test_against_nomatch(runtmp, capfd):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_against_nomatch(runtmp, capfd, zip_against):
     # test with 'against' file containing a non-matching ksize
     query = get_test_data('SRR606249.sig.gz')
     against_list = runtmp.output('against.txt')
@@ -287,6 +349,9 @@ def test_against_nomatch(runtmp, capfd):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig1, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -301,7 +366,8 @@ def test_against_nomatch(runtmp, capfd):
     assert 'WARNING: skipped 1 search paths - no compatible signatures.' in captured.err
 
 
-def test_md5s(runtmp):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_md5s(runtmp, zip_against):
     # check that the correct md5sums (of the original sketches) are in
     # the output files
     query = get_test_data('SRR606249.sig.gz')
@@ -312,6 +378,9 @@ def test_md5s(runtmp):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -351,7 +420,8 @@ def test_md5s(runtmp):
             assert ss.md5sum() in md5s
 
 
-def test_csv_columns_vs_sourmash_prefetch(runtmp):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_csv_columns_vs_sourmash_prefetch(runtmp, zip_against):
     # the column names should be strict subsets of sourmash prefetch cols
     query = get_test_data('SRR606249.sig.gz')
     against_list = runtmp.output('against.txt')
@@ -361,6 +431,9 @@ def test_csv_columns_vs_sourmash_prefetch(runtmp):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -388,7 +461,8 @@ def test_csv_columns_vs_sourmash_prefetch(runtmp):
     assert not g_keys - sp_keys, g_keys - sp_keys
 
 
-def test_fastgather_gatherout_as_picklist(runtmp):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_fastgather_gatherout_as_picklist(runtmp, zip_against):
     # should be able to use fastgather gather output as picklist
     query = get_test_data('SRR606249.sig.gz')
     against_list = runtmp.output('against.txt')
@@ -398,6 +472,9 @@ def test_fastgather_gatherout_as_picklist(runtmp):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')
@@ -426,7 +503,8 @@ def test_fastgather_gatherout_as_picklist(runtmp):
     assert picklist_df.equals(full_df)
 
 
-def test_fastgather_prefetchout_as_picklist(runtmp):
+@pytest.mark.parametrize('zip_against', [False, True])
+def test_fastgather_prefetchout_as_picklist(runtmp, zip_against):
     # should be able to use fastgather prefetch output as picklist
     query = get_test_data('SRR606249.sig.gz')
     against_list = runtmp.output('against.txt')
@@ -436,6 +514,9 @@ def test_fastgather_prefetchout_as_picklist(runtmp):
     sig63 = get_test_data('63.fa.sig.gz')
 
     make_file_list(against_list, [sig2, sig47, sig63])
+
+    if zip_against:
+        against_list = zip_siglist(runtmp, against_list, runtmp.output('against.zip'))
 
     g_output = runtmp.output('gather.csv')
     p_output = runtmp.output('prefetch.csv')

--- a/src/python/tests/test_multigather.py
+++ b/src/python/tests/test_multigather.py
@@ -20,17 +20,19 @@ def make_file_list(filename, paths):
         fp.write("\n")
 
 
+def index_siglist(runtmp, siglist, db):
+    # build index
+    runtmp.sourmash('scripts', 'index', siglist,
+                    '-o', db)
+    return db
+
+
 def test_installed(runtmp):
     with pytest.raises(utils.SourmashCommandFailed):
         runtmp.sourmash('scripts', 'fastmultigather')
 
     assert 'usage:  fastmultigather' in runtmp.last_result.err
 
-def index_siglist(runtmp, siglist, db):
-    # build index
-    runtmp.sourmash('scripts', 'index', siglist,
-                    '-o', db)
-    return db
 
 @pytest.mark.parametrize('indexed', [False, True])
 def test_simple(runtmp, indexed):


### PR DESCRIPTION
Follow up to #105: 
- Enables sourmash zipfiles to be used as database input for `fastgather`.

to do:
- [x] use file loading functions from #105 
- [x] modify tests as needed for unified reporting logic
  - we're not using the reporting (b/c different loading), but I unified the output phrasing in anticipation of better zip loading in the future (see note).
- [x] add tests for loading from zipfile

Note: To keep this simple, I was just planning on adding suboptimal zip loading, as `fastgather` loads database signatures using a sketch template and `threshold` parameter, which we don't have in the zip loading function. 

These could/should be added to allow directing loading of signatures from the zipfile (as suggested in #113).

Closes #108 