### PR TITLE
MRG: clearer message for manysketch

### DIFF
--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -187,7 +187,10 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
             // progress report at threshold
             if i != 0 && i % reporting_threshold == 0 {
                 let percent_processed = ((i as f64 / n_fastas as f64) * 100.0).round();
-                eprintln!("Starting {}th fasta file ({}% of total)", i, percent_processed);
+                eprintln!(
+                    "Starting {}th fasta file ({}% of total)",
+                    i, percent_processed
+                );
             }
 
             let mut data: Vec<u8> = vec![];

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -187,7 +187,7 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
             // progress report at threshold
             if i != 0 && i % reporting_threshold == 0 {
                 let percent_processed = ((i as f64 / n_fastas as f64) * 100.0).round();
-                eprintln!("Processed {} fasta files ({}% done)", i, percent_processed);
+                eprintln!("Starting {}th fasta file ({}% of total)", i, percent_processed);
             }
 
             let mut data: Vec<u8> = vec![];

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -187,10 +187,7 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
             // progress report at threshold
             if i != 0 && i % reporting_threshold == 0 {
                 let percent_processed = ((i as f64 / n_fastas as f64) * 100.0).round();
-                eprintln!(
-                    "Starting {}th fasta file ({}% of total)",
-                    i, percent_processed
-                );
+                eprintln!("Starting file {}/{} ({}%)", i, n_fastas, percent_processed);
             }
 
             let mut data: Vec<u8> = vec![];


### PR DESCRIPTION
For a small csv file (especially with large files), the prior printout was misleading. After opening one file per thread, the message claims x% done. In reality, we've just opened the files to start building sketches. 