### PR TITLE
MRG: actually iterate through reads

### DIFF
--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use rayon::prelude::*;
 
 use crate::utils::{load_fasta_fromfile, sigwriter, Params, ZipMessage};
-use needletail::{parse_fastx_file, Sequence};
+use needletail::parse_fastx_file;
 use sourmash::cmd::ComputeParameters;
 use sourmash::signature::Signature;
 use std::path::Path;

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use rayon::prelude::*;
 
 use crate::utils::{load_fasta_fromfile, sigwriter, Params, ZipMessage};
-use needletail::{parse_fastx_file, Sequence, FastxReader};
+use needletail::{parse_fastx_file, FastxReader, Sequence};
 use sourmash::cmd::ComputeParameters;
 use sourmash::signature::Signature;
 use std::path::Path;
@@ -240,7 +240,7 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
                 } else {
                     Ok(())
                 }
-            }
+            },
         );
 
     // After the parallel work, send the WriteManifest message

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -189,7 +189,6 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
                 eprintln!("Starting file {}/{} ({}%)", i, n_fastas, percent_processed);
             }
 
-            let mut data: Vec<u8> = vec![];
             // build sig templates from params
             let (mut sigs, sig_params) = build_siginfo(&params_vec, moltype, name, filename);
             // if no sigs to build, skip
@@ -211,9 +210,8 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
             while let Some(record_result) = reader.next() {
                 match record_result {
                     Ok(record) => {
-                        // normalize to make sure all the bases are consistently capitalized and
-                        // that we remove the newlines since this is FASTA
-                        let norm_seq = record.normalize(false);
+                        // do we need to normalize to make sure all the bases are consistently capitalized?
+                        // let norm_seq = record.normalize(false);
                         for sig in &mut sigs {
                             if moltype == "protein" {
                                 sig.add_protein(&record.seq()).unwrap();

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -181,16 +181,12 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
     let send_result = fileinfo
         .par_iter()
         .filter_map(|(name, filename, moltype)| {
-            let i = processed_fastas.fetch_add(1, atomic::Ordering::SeqCst);
+            // increment processed_fastas counter; make 1-based for % reporting
+            let i = processed_fastas.fetch_add(1, atomic::Ordering::SeqCst) + 1;
             // progress report at threshold
             if i != 0 && i % reporting_threshold == 0 {
                 let percent_processed = ((i as f64 / n_fastas as f64) * 100.0).round();
-                eprintln!(
-                    "Starting file {}/{} ({}%)",
-                    i + 1,
-                    n_fastas,
-                    percent_processed
-                );
+                eprintln!("Starting file {}/{} ({}%)", i, n_fastas, percent_processed);
             }
 
             let mut data: Vec<u8> = vec![];

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -185,7 +185,12 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
             // progress report at threshold
             if i != 0 && i % reporting_threshold == 0 {
                 let percent_processed = ((i as f64 / n_fastas as f64) * 100.0).round();
-                eprintln!("Starting file {}/{} ({}%)", i, n_fastas, percent_processed);
+                eprintln!(
+                    "Starting file {}/{} ({}%)",
+                    i + 1,
+                    n_fastas,
+                    percent_processed
+                );
             }
 
             let mut data: Vec<u8> = vec![];


### PR DESCRIPTION
Previously, `manysketch` was reading entire fasta files into memory. 
I always intended to iterate, I just lost track of it.

Revealed by #122 