### PR TITLE
MRG: fix clippy stuff; bump to v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-branchwater"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-branchwater"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -49,7 +49,7 @@ pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     );
 
     let matchlist_filename = matchlist_filename.as_ref().to_string_lossy().to_string();
-    let (matchlist_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(&matchlist_filename)?;
+    let (matchlist_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(matchlist_filename)?;
 
     eprintln!("Loaded {} sig paths in matchlist", matchlist_paths.len());
 

--- a/src/manysketch.rs
+++ b/src/manysketch.rs
@@ -198,7 +198,7 @@ pub fn manysketch<P: AsRef<Path> + Sync>(
             }
 
             // Open fasta file reader
-            let mut reader = match parse_fastx_file(&filename) {
+            let mut reader = match parse_fastx_file(filename) {
                 Ok(r) => r,
                 Err(err) => {
                     eprintln!("Error opening file {}: {:?}", filename.display(), err);

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -35,7 +35,7 @@ pub fn mastiff_manysearch<P: AsRef<Path>>(
 
     // Load query paths
     let queryfile_name = queries_file.as_ref().to_string_lossy().to_string();
-    let (query_paths, _) = load_sigpaths_from_zip_or_pathlist(&queries_file)?;
+    let (query_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(&queries_file)?;
 
     // if query_paths is empty, exit with error
     if query_paths.is_empty() {
@@ -161,6 +161,8 @@ pub fn mastiff_manysearch<P: AsRef<Path>>(
             failed_paths
         );
     }
+
+    // _temp_dir goes out of scope => is deleted.
 
     Ok(())
 }

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -35,7 +35,7 @@ pub fn mastiff_manysearch<P: AsRef<Path>>(
 
     // Load query paths
     let queryfile_name = queries_file.as_ref().to_string_lossy().to_string();
-    let (query_paths, temp_dir) = load_sigpaths_from_zip_or_pathlist(&queries_file)?;
+    let (query_paths, _) = load_sigpaths_from_zip_or_pathlist(&queries_file)?;
 
     // if query_paths is empty, exit with error
     if query_paths.is_empty() {


### PR DESCRIPTION
This PR cleans up several clippy suggestions, and also bumps the version to v0.8.1.