### PR TITLE
MRG: only load zip paths with compatible sketches

### DIFF
--- a/src/fastgather.rs
+++ b/src/fastgather.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use crate::utils::{
     consume_query_by_gather, load_sigpaths_from_zip_or_pathlist, load_sketches_above_threshold,
-    prepare_query, write_prefetch,
+    prepare_query, write_prefetch, ReportType,
 };
 
 pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
@@ -49,7 +49,8 @@ pub fn fastgather<P: AsRef<Path> + std::fmt::Debug + std::fmt::Display + Clone>(
     );
 
     let matchlist_filename = matchlist_filename.as_ref().to_string_lossy().to_string();
-    let (matchlist_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(matchlist_filename)?;
+    let (matchlist_paths, _temp_dir) =
+        load_sigpaths_from_zip_or_pathlist(matchlist_filename, &template, ReportType::Against)?;
 
     eprintln!("Loaded {} sig paths in matchlist", matchlist_paths.len());
 

--- a/src/fastmultigather.rs
+++ b/src/fastmultigather.rs
@@ -34,7 +34,8 @@ pub fn fastmultigather<P: AsRef<Path> + std::fmt::Debug + Clone>(
 
     // load the list of query paths
     let queryfile_name = query_filenames.as_ref().to_string_lossy().to_string();
-    let (querylist_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(&query_filenames)?;
+    let (querylist_paths, _temp_dir) =
+        load_sigpaths_from_zip_or_pathlist(&query_filenames, &template, ReportType::Query)?;
     println!("Loaded {} sig paths in querylist", querylist_paths.len());
 
     let threshold_hashes: u64 = {

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,7 +2,7 @@ use sourmash::index::revindex::RevIndex;
 use sourmash::sketch::Sketch;
 use std::path::Path;
 
-use crate::utils::load_sigpaths_from_zip_or_pathlist;
+use crate::utils::{load_sigpaths_from_zip_or_pathlist, ReportType};
 
 pub fn index<P: AsRef<Path>>(
     siglist: P,
@@ -13,7 +13,8 @@ pub fn index<P: AsRef<Path>>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("Loading siglist");
 
-    let (index_sigs, _temp_dir) = load_sigpaths_from_zip_or_pathlist(&siglist)?;
+    let (index_sigs, _temp_dir) =
+        load_sigpaths_from_zip_or_pathlist(&siglist, &template, ReportType::Index)?;
 
     // if index_sigs pathlist is empty, bail
     if index_sigs.is_empty() {

--- a/src/manysearch.rs
+++ b/src/manysearch.rs
@@ -36,7 +36,8 @@ pub fn manysearch<P: AsRef<Path>>(
 
     // Load all _paths_, not signatures, into memory.
     let siglist_name = siglist.as_ref().to_string_lossy().to_string();
-    let (search_sigs_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(siglist)?;
+    let (search_sigs_paths, _temp_dir) =
+        load_sigpaths_from_zip_or_pathlist(siglist, &template, ReportType::Against)?;
 
     if search_sigs_paths.is_empty() {
         bail!("No signatures to search loaded, exiting.");

--- a/src/mastiff_manygather.rs
+++ b/src/mastiff_manygather.rs
@@ -14,7 +14,9 @@ use std::sync::atomic::AtomicUsize;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
-use crate::utils::{is_revindex_database, load_sigpaths_from_zip_or_pathlist, prepare_query};
+use crate::utils::{
+    is_revindex_database, load_sigpaths_from_zip_or_pathlist, prepare_query, ReportType,
+};
 
 pub fn mastiff_manygather<P: AsRef<Path>>(
     queries_file: P,
@@ -35,7 +37,8 @@ pub fn mastiff_manygather<P: AsRef<Path>>(
 
     // Load query paths
     let queryfile_name = queries_file.as_ref().to_string_lossy().to_string();
-    let (query_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(&queries_file)?;
+    let (query_paths, _temp_dir) =
+        load_sigpaths_from_zip_or_pathlist(&queries_file, &template, ReportType::Query)?;
 
     // set up a multi-producer, single-consumer channel.
     let (send, recv) = std::sync::mpsc::sync_channel(rayon::current_num_threads());

--- a/src/mastiff_manysearch.rs
+++ b/src/mastiff_manysearch.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::AtomicUsize;
 
 use crate::utils::{
     csvwriter_thread, is_revindex_database, load_sigpaths_from_zip_or_pathlist, prepare_query,
-    SearchResult,
+    ReportType, SearchResult,
 };
 
 pub fn mastiff_manysearch<P: AsRef<Path>>(
@@ -35,7 +35,8 @@ pub fn mastiff_manysearch<P: AsRef<Path>>(
 
     // Load query paths
     let queryfile_name = queries_file.as_ref().to_string_lossy().to_string();
-    let (query_paths, _temp_dir) = load_sigpaths_from_zip_or_pathlist(&queries_file)?;
+    let (query_paths, _temp_dir) =
+        load_sigpaths_from_zip_or_pathlist(&queries_file, &template, ReportType::Query)?;
 
     // if query_paths is empty, exit with error
     if query_paths.is_empty() {

--- a/src/python/tests/test_index.py
+++ b/src/python/tests/test_index.py
@@ -154,17 +154,17 @@ def test_index_zipfile(runtmp, capfd):
     assert 'Found 3 filepaths' in captured.err
 
 
-def test_index_zipfile_multik(runtmp, capfd):
-    # test basic index from sourmash zipfile
+def test_index_zipfile_multiparam(runtmp, capfd):
+    # test index from sourmash zipfile with multiple ksizes / scaled
     siglist = runtmp.output('db-sigs.txt')
 
     sig2 = get_test_data('2.fa.sig.gz')
     sig47 = get_test_data('47.fa.sig.gz')
     sig63 = get_test_data('63.fa.sig.gz')
     sig1 = get_test_data('1.combined.sig.gz')
+    srr = get_test_data('SRR606249.sig.gz')
 
-    make_file_list(siglist, [sig2, sig47, sig63, sig1])
-    # make_file_list(siglist, [sig1])
+    make_file_list(siglist, [sig2, sig47, sig63, sig1, srr])
 
     zipf = runtmp.output('sigs.zip')
 
@@ -180,8 +180,8 @@ def test_index_zipfile_multik(runtmp, capfd):
     assert 'index is done' in runtmp.last_result.err
     captured = capfd.readouterr()
     print(captured.err)
+    assert 'WARNING: skipped 3 index paths - no compatible signatures.' in captured.err
     assert 'Found 4 filepaths' in captured.err
-    assert 'WARNING: skipped 2 index paths - no compatible signatures.' in captured.err
 
 
 def test_index_zipfile_bad(runtmp, capfd):

--- a/src/python/tests/test_index.py
+++ b/src/python/tests/test_index.py
@@ -154,6 +154,36 @@ def test_index_zipfile(runtmp, capfd):
     assert 'Found 3 filepaths' in captured.err
 
 
+def test_index_zipfile_multik(runtmp, capfd):
+    # test basic index from sourmash zipfile
+    siglist = runtmp.output('db-sigs.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig47 = get_test_data('47.fa.sig.gz')
+    sig63 = get_test_data('63.fa.sig.gz')
+    sig1 = get_test_data('1.combined.sig.gz')
+
+    make_file_list(siglist, [sig2, sig47, sig63, sig1])
+    # make_file_list(siglist, [sig1])
+
+    zipf = runtmp.output('sigs.zip')
+
+    runtmp.sourmash('sig', 'cat', siglist, '-o', zipf)
+
+    output = runtmp.output('db.rdb')
+
+    runtmp.sourmash('scripts', 'index', zipf,
+                    '-o', output)
+    assert os.path.exists(output)
+    print(runtmp.last_result.err)
+
+    assert 'index is done' in runtmp.last_result.err
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert 'Found 4 filepaths' in captured.err
+    assert 'WARNING: skipped 2 index paths - no compatible signatures.' in captured.err
+
+
 def test_index_zipfile_bad(runtmp, capfd):
     # test with a bad input zipfile (a .sig.gz file renamed as zip file)
     sig2 = get_test_data('2.fa.sig.gz')


### PR DESCRIPTION
- Improves sigpath loading from zips by checking for compatibility with desired sketch parameters first.
- Allows `sourmash scripts index` with a multi-parameter zipfile.

Fixes #109
Fixes #113