### PR TITLE
MRG: read `sig.gz_{n}` sigs from zipfiles

### DIFF
--- a/src/mastiff_manygather.rs
+++ b/src/mastiff_manygather.rs
@@ -94,10 +94,8 @@ pub fn mastiff_manygather<P: AsRef<Path>>(
                         let threshold = threshold_bp / query.minhash.scaled() as usize;
 
                         // mastiff gather code
-                        println!("Building counter");
                         let (counter, query_colors, hash_to_color) =
                             db.prepare_gather_counters(&query.minhash);
-                        println!("Counter built");
 
                         let matches = db.gather(
                             counter,

--- a/src/python/tests/test_index.py
+++ b/src/python/tests/test_index.py
@@ -187,6 +187,35 @@ def test_index_zipfile(runtmp, capfd):
     assert 'Found 3 filepaths' in captured.err
 
 
+def test_index_zipfile_repeated_md5sums(runtmp, capfd):
+    # test that we're reading all files, including repeated md5sums
+    siglist = runtmp.output('db-sigs.txt')
+
+    sig2 = get_test_data('2.fa.sig.gz')
+    sig2a = runtmp.output('sig2a.sig.gz')
+    sig2b = runtmp.output('sig2b.sig.gz')
+    runtmp.sourmash('sig', 'rename', sig2, 'name2', '-o', sig2a)
+    runtmp.sourmash('sig', 'rename', sig2, 'name3', '-o', sig2b)
+
+    make_file_list(siglist, [sig2, sig2a, sig2b])
+
+    zipf = runtmp.output('sigs.zip')
+    runtmp.sourmash('sig', 'cat', siglist, '-o', zipf)
+
+    output = runtmp.output('db.rdb')
+
+    runtmp.sourmash('scripts', 'index', zipf,
+                    '-o', output)
+    assert os.path.exists(output)
+    print(runtmp.last_result.err)
+
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert 'Found 3 filepaths' in captured.err
+    assert 'index is done' in runtmp.last_result.err
+
+
 def test_index_zipfile_multiparam(runtmp, capfd):
     # test index from sourmash zipfile with multiple ksizes / scaled /moltype
     siglist = runtmp.output('db-sigs.txt')

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -270,7 +270,8 @@ pub fn load_sigpaths_from_zip<P: AsRef<Path>>(
             .unwrap()
             .to_str()
             .unwrap();
-        if file_name.contains(".sig") || file_name.contains(".sig.gz") { // account for sig.gz_0 bug in sourmash
+        // use contains to account for sig.gz_0 bug in sourmash
+        if file_name.contains(".sig") || file_name.contains(".sig.gz") {
             // read file
             let mut contents = Vec::new();
             file.read_to_end(&mut contents)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -270,7 +270,8 @@ pub fn load_sigpaths_from_zip<P: AsRef<Path>>(
             .unwrap()
             .to_str()
             .unwrap();
-        if file_name.ends_with(".sig") || file_name.ends_with(".sig.gz") {
+        // if file_name.ends_with(".sig") || file_name.ends_with(".sig.gz") {
+        if file_name.contains(".sig") || file_name.contains(".sig.gz") { // account for sig.gz_0 bug in sourmash
             // read file
             let mut contents = Vec::new();
             file.read_to_end(&mut contents)?;
@@ -532,7 +533,8 @@ pub fn load_sketches_from_zip<P: AsRef<Path>>(
             .unwrap()
             .to_owned();
 
-        if !file_name.ends_with(".sig") && !file_name.ends_with(".sig.gz") {
+        // if !file_name.ends_with(".sig") && !file_name.ends_with(".sig.gz") {
+        if !file_name.contains(".sig") && !file_name.contains(".sig.gz") {
             continue;
         }
         if let Ok(sigs) = Signature::from_reader(&mut file) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -270,7 +270,6 @@ pub fn load_sigpaths_from_zip<P: AsRef<Path>>(
             .unwrap()
             .to_str()
             .unwrap();
-        // if file_name.ends_with(".sig") || file_name.ends_with(".sig.gz") {
         if file_name.contains(".sig") || file_name.contains(".sig.gz") { // account for sig.gz_0 bug in sourmash
             // read file
             let mut contents = Vec::new();
@@ -533,7 +532,6 @@ pub fn load_sketches_from_zip<P: AsRef<Path>>(
             .unwrap()
             .to_owned();
 
-        // if !file_name.ends_with(".sig") && !file_name.ends_with(".sig.gz") {
         if !file_name.contains(".sig") && !file_name.contains(".sig.gz") {
             continue;
         }


### PR DESCRIPTION
as noted in https://github.com/sourmash-bio/sourmash/issues/2749#issuecomment-1715762525, sourmash zipfiles store repeated md5sums as `.sig.gz_{n}` instead of `_{n}.sig.gz`. This PR allows us to read those files as well, rather than skipping over them.

