### PR TITLE
Add "compilers" to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ dependencies:
     - maturin>=1,<2
     - pytest
     - pandas
+    - compilers


### PR DESCRIPTION
As mentioned here : https://github.com/sourmash-bio/pyo3_branchwater/issues/148, added `compilers` to the `environment.yml` file which then resulted in a successful installation of `branchwater`!

```
(branchwater-dev)
 ✘  ♥ 93%  Mon 13 Nov - 11:11  ~/code/pyo3_branchwater   origin ☊ main ↓2 1☀ 1● 
 @olgabot  mamb env create --file environment.yml --name branchwater-dev-v2
zsh: correct 'mamb' to 'mamba' [nyae]? y
conda-forge/osx-64                                          Using cache
conda-forge/noarch                                          Using cache
bioconda/osx-64                                             Using cache
bioconda/noarch                                             Using cache
pkgs/main/osx-64                                              No change
pkgs/main/noarch                                              No change
pkgs/r/noarch                                                 No change
pkgs/r/osx-64                                                 No change


Looking for: ["sourmash[version='>=4.8.3,<5']", 'pip', 'rust', "maturin[version='>=1,<2']", 'pytest', 'pandas', 'compilers']


Transaction

  Prefix: /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2

  Updating specs:

   - sourmash[version='>=4.8.3,<5']
   - pip
   - rust
   - maturin[version='>=1,<2']
   - pytest
   - pandas
   - compilers


  Package                              Version  Build               Channel                  Size
───────────────────────────────────────────────────────────────────────────────────────────────────
  Install:
───────────────────────────────────────────────────────────────────────────────────────────────────

  + bitstring                            3.1.9  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + brotli                               1.1.0  h0dc2134_1          conda-forge/osx-64     Cached
  + brotli-bin                           1.1.0  h0dc2134_1          conda-forge/osx-64     Cached
  + bzip2                                1.0.8  h10d778d_5          conda-forge/osx-64     Cached
  + c-compiler                           1.6.0  h63c33a9_0          conda-forge/osx-64        6kB
  + ca-certificates                  2023.7.22  h8857fd0_0          conda-forge/osx-64     Cached
  + cachetools                           4.2.4  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + cctools                            973.0.1  hd9ad811_15         conda-forge/osx-64       22kB
  + cctools_osx-64                     973.0.1  habff3f6_15         conda-forge/osx-64        1MB
  + certifi                          2023.7.22  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + cffi                                1.16.0  py312h38bf5a0_0     conda-forge/osx-64     Cached
  + clang                               15.0.7  h694c41f_3          conda-forge/osx-64      133kB
  + clang-15                            15.0.7  default_hdb78580_3  conda-forge/osx-64      795kB
  + clang_impl_osx-64                   15.0.7  h03d6864_6          conda-forge/osx-64       18kB
  + clang_osx-64                        15.0.7  hb91bd55_6          conda-forge/osx-64       21kB
  + clangxx                             15.0.7  default_hdb78580_3  conda-forge/osx-64      133kB
  + clangxx_impl_osx-64                 15.0.7  h3d2d1bf_6          conda-forge/osx-64       18kB
  + clangxx_osx-64                      15.0.7  h655633e_6          conda-forge/osx-64       19kB
  + colorama                             0.4.6  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + compiler-rt                         15.0.7  he1888fc_1          conda-forge/osx-64       92kB
  + compiler-rt_osx-64                  15.0.7  he1888fc_1          conda-forge/noarch       11MB
  + compilers                            1.6.0  h694c41f_0          conda-forge/osx-64        7kB
  + contourpy                            1.2.0  py312hbf0bb39_0     conda-forge/osx-64     Cached
  + cxx-compiler                         1.6.0  h1c7c39f_0          conda-forge/osx-64        6kB
  + cycler                              0.12.1  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + deprecation                          2.1.0  pyh9f0ad1d_0        conda-forge/noarch     Cached
  + exceptiongroup                       1.1.3  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + fonttools                           4.44.0  py312h41838bb_0     conda-forge/osx-64     Cached
  + fortran-compiler                     1.6.0  h932d759_0          conda-forge/osx-64        6kB
  + freetype                            2.12.1  h60636b9_2          conda-forge/osx-64     Cached
  + gfortran                            12.3.0  h2c809b3_1          conda-forge/osx-64       32kB
  + gfortran_impl_osx-64                12.3.0  h54fd467_1          conda-forge/osx-64       21MB
  + gfortran_osx-64                     12.3.0  h18f7dce_1          conda-forge/osx-64       35kB
  + gmp                                  6.3.0  h93d8f39_0          conda-forge/osx-64      521kB
  + icu                                   73.2  hf5e326d_0          conda-forge/osx-64     Cached
  + iniconfig                            2.0.0  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + isl                                   0.25  hb486fe8_0          conda-forge/osx-64     Cached
  + kiwisolver                           1.4.5  py312h49ebfd2_1     conda-forge/osx-64     Cached
  + lcms2                                 2.15  hd6ba6f3_3          conda-forge/osx-64     Cached
  + ld64                                   609  ha91a046_15         conda-forge/osx-64       19kB
  + ld64_osx-64                            609  h0fd476b_15         conda-forge/osx-64        1MB
  + lerc                                 4.0.0  hb486fe8_0          conda-forge/osx-64     Cached
  + libblas                              3.9.0  19_osx64_openblas   conda-forge/osx-64     Cached
  + libbrotlicommon                      1.1.0  h0dc2134_1          conda-forge/osx-64     Cached
  + libbrotlidec                         1.1.0  h0dc2134_1          conda-forge/osx-64     Cached
  + libbrotlienc                         1.1.0  h0dc2134_1          conda-forge/osx-64     Cached
  + libcblas                             3.9.0  19_osx64_openblas   conda-forge/osx-64     Cached
  + libclang-cpp15                      15.0.7  default_hdb78580_3  conda-forge/osx-64       12MB
  + libcxx                              16.0.6  hd57cbcb_0          conda-forge/osx-64     Cached
  + libdeflate                            1.19  ha4e1b8e_0          conda-forge/osx-64     Cached
  + libexpat                             2.5.0  hf0c8a7f_1          conda-forge/osx-64     Cached
  + libffi                               3.4.2  h0d85af4_5          conda-forge/osx-64     Cached
  + libgfortran                          5.0.0  13_2_0_h97931a8_1   conda-forge/osx-64     Cached
  + libgfortran-devel_osx-64            12.3.0  h0b6f5ec_1          conda-forge/noarch      454kB
  + libgfortran5                        13.2.0  h2873a65_1          conda-forge/osx-64     Cached
  + libiconv                              1.17  hac89ed1_0          conda-forge/osx-64     Cached
  + libjpeg-turbo                        3.0.0  h0dc2134_1          conda-forge/osx-64     Cached
  + liblapack                            3.9.0  19_osx64_openblas   conda-forge/osx-64     Cached
  + libllvm15                           15.0.7  he4b1e75_3          conda-forge/osx-64       24MB
  + libopenblas                         0.3.24  openmp_h48a4ad5_0   conda-forge/osx-64     Cached
  + libpng                              1.6.39  ha978bb4_0          conda-forge/osx-64     Cached
  + libsqlite                           3.44.0  h92b6c6a_0          conda-forge/osx-64     Cached
  + libtiff                              4.6.0  h684deea_2          conda-forge/osx-64     Cached
  + libwebp-base                         1.3.2  h0dc2134_0          conda-forge/osx-64     Cached
  + libxcb                                1.15  hb7f2c08_0          conda-forge/osx-64     Cached
  + libxml2                             2.11.5  h3346baf_1          conda-forge/osx-64     Cached
  + libzlib                             1.2.13  h8a1eda9_5          conda-forge/osx-64     Cached
  + llvm-openmp                         17.0.4  hb6ac08f_0          conda-forge/osx-64     Cached
  + llvm-tools                          15.0.7  he4b1e75_3          conda-forge/osx-64       11MB
  + matplotlib-base                      3.8.1  py312h1fe5000_0     conda-forge/osx-64     Cached
  + maturin                              1.3.1  py312h54f8cdb_0     conda-forge/osx-64     Cached
  + mpc                                  1.3.1  h81bd1dd_0          conda-forge/osx-64      109kB
  + mpfr                                 4.2.1  h0c69b56_0          conda-forge/osx-64      377kB
  + munkres                              1.1.4  pyh9f0ad1d_0        conda-forge/noarch     Cached
  + ncurses                                6.4  h93d8f39_2          conda-forge/osx-64     Cached
  + numpy                               1.26.0  py312h5df92dc_0     conda-forge/osx-64     Cached
  + openjpeg                             2.5.0  ha4da562_3          conda-forge/osx-64     Cached
  + openssl                              3.1.4  hd75f5a5_0          conda-forge/osx-64     Cached
  + packaging                             23.2  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + pandas                               2.1.3  py312haf8ecfc_0     conda-forge/osx-64     Cached
  + pillow                              10.1.0  py312h0c70c2f_0     conda-forge/osx-64     Cached
  + pip                                 23.3.1  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + pluggy                               1.3.0  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + pthread-stubs                          0.4  hc929b4f_1001       conda-forge/osx-64     Cached
  + pycparser                             2.21  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + pyparsing                            3.1.1  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + pytest                               7.4.3  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + python                              3.12.0  h30d4d87_0_cpython  conda-forge/osx-64     Cached
  + python-dateutil                      2.8.2  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + python-tzdata                       2023.3  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + python_abi                            3.12  4_cp312             conda-forge/osx-64     Cached
  + pytz                          2023.3.post1  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + readline                               8.2  h9e318b2_1          conda-forge/osx-64     Cached
  + rust                                1.73.0  h7e1429e_2          conda-forge/osx-64     Cached
  + rust-std-x86_64-apple-darwin        1.73.0  h38e4360_2          conda-forge/noarch     Cached
  + scipy                               1.11.3  py312h2c2f0bb_1     conda-forge/osx-64     Cached
  + screed                               1.1.2  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + setuptools                          68.2.2  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + sigtool                              0.1.3  h88f4db0_0          conda-forge/osx-64     Cached
  + six                                 1.16.0  pyh6c4a22f_0        conda-forge/noarch     Cached
  + sourmash                             4.8.4  hdfd78af_0          bioconda/noarch        Cached
  + sourmash-minimal                     4.8.4  py312h6e28e45_1     conda-forge/osx-64     Cached
  + tapi                             1100.0.11  h9ce4665_0          conda-forge/osx-64     Cached
  + tk                                  8.6.13  h1abcd95_1          conda-forge/osx-64     Cached
  + tomli                                2.0.1  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + tzdata                               2023c  h71feb2d_0          conda-forge/noarch     Cached
  + wheel                               0.41.3  pyhd8ed1ab_0        conda-forge/noarch     Cached
  + xorg-libxau                         1.0.11  h0dc2134_0          conda-forge/osx-64     Cached
  + xorg-libxdmcp                        1.1.3  h35c211d_0          conda-forge/osx-64     Cached
  + xz                                   5.2.6  h775f41a_0          conda-forge/osx-64     Cached
  + zlib                                1.2.13  h8a1eda9_5          conda-forge/osx-64     Cached
  + zstd                                 1.5.5  h829000d_0          conda-forge/osx-64     Cached

  Summary:

  Install: 112 packages

  Total download: 84MB

───────────────────────────────────────────────────────────────────────────────────────────────────

mpc                                                109.1kB @ 394.5kB/s  0.3s
mpfr                                               376.5kB @   1.2MB/s  0.3s
libgfortran-devel_osx-64                           453.9kB @   1.5MB/s  0.3s
gmp                                                520.9kB @   1.7MB/s  0.3s
clangxx_impl_osx-64                                 17.7kB @  48.9kB/s  0.1s
clang                                              132.8kB @ 360.6kB/s  0.1s
compiler-rt                                         92.1kB @ 229.4kB/s  0.1s
fortran-compiler                                     6.3kB @  15.1kB/s  0.0s
clangxx_osx-64                                      19.4kB @  46.0kB/s  0.1s
ld64                                                19.1kB @  41.2kB/s  0.0s
clangxx                                            133.0kB @ 278.4kB/s  0.0s
cctools_osx-64                                       1.1MB @   2.3MB/s  0.2s
clang_osx-64                                        20.6kB @  40.6kB/s  0.0s
gfortran                                            31.9kB @  60.0kB/s  0.1s
clang_impl_osx-64                                   17.5kB @  29.7kB/s  0.1s
clang-15                                           794.7kB @   1.3MB/s  0.1s
cxx-compiler                                         6.3kB @   9.8kB/s  0.1s
gfortran_osx-64                                     35.0kB @  49.6kB/s  0.1s
ld64_osx-64                                          1.1MB @   1.3MB/s  0.3s
c-compiler                                           6.2kB @   7.0kB/s  0.1s
libllvm15                                           23.9MB @  25.1MB/s  1.0s
compilers                                            7.1kB @   6.8kB/s  0.1s
cctools                                             21.9kB @  19.9kB/s  0.1s
llvm-tools                                          11.4MB @   9.3MB/s  0.8s
libclang-cpp15                                      12.4MB @   7.3MB/s  1.0s
gfortran_impl_osx-64                                20.6MB @  11.7MB/s  1.1s
compiler-rt_osx-64                                  11.2MB @   5.9MB/s  1.0s
Preparing transaction: done
Verifying transaction: done
Executing transaction: done
#
# To activate this environment, use
#
#     $ conda activate branchwater-dev-v2
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Retrieving notices: ...working... done
(branchwater-dev)
 ♥ 91%  Mon 13 Nov - 11:14  ~/code/pyo3_branchwater   origin ☊ main ↓2 1☀ 1● 
 @olgabot  conda activate branchwater-dev-v2
(branchwater-dev-v2)
 ♥ 90%  Mon 13 Nov - 11:15  ~/code/pyo3_branchwater   origin ☊ main ↓2 1☀ 1● 
 @olgabot  pip install -e .
Obtaining file:///Users/olgabot/code/pyo3_branchwater
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: sourmash<5,>=4.8.3 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from pyo3-branchwater==0.8.2) (4.8.4)
Requirement already satisfied: screed<2,>=1.1.2 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (1.1.2)
Requirement already satisfied: cffi>=1.14.0 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (1.16.0)
Requirement already satisfied: numpy in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (1.26.0)
Requirement already satisfied: matplotlib in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (3.8.1)
Requirement already satisfied: scipy in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (1.11.3)
Requirement already satisfied: deprecation>=2.0.6 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (2.1.0)
Requirement already satisfied: cachetools<6,>=4 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (4.2.4)
Requirement already satisfied: bitstring<5,>=3.1.9 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (3.1.9)
Requirement already satisfied: pycparser in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from cffi>=1.14.0->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (2.21)
Requirement already satisfied: packaging in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from deprecation>=2.0.6->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (23.2)
Requirement already satisfied: contourpy>=1.0.1 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from matplotlib->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (1.2.0)
Requirement already satisfied: cycler>=0.10 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from matplotlib->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (0.12.1)
Requirement already satisfied: fonttools>=4.22.0 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from matplotlib->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (4.44.0)
Requirement already satisfied: kiwisolver>=1.3.1 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from matplotlib->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (1.4.5)
Requirement already satisfied: pillow>=8 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from matplotlib->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (10.1.0)
Requirement already satisfied: pyparsing>=2.3.1 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from matplotlib->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (3.1.1)
Requirement already satisfied: python-dateutil>=2.7 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from matplotlib->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (2.8.2)
Requirement already satisfied: six>=1.5 in /Users/olgabot/opt/miniconda3/envs/branchwater-dev-v2/lib/python3.12/site-packages (from python-dateutil>=2.7->matplotlib->sourmash<5,>=4.8.3->pyo3-branchwater==0.8.2) (1.16.0)
Building wheels for collected packages: pyo3-branchwater
  Building editable for pyo3-branchwater (pyproject.toml) ... done
  Created wheel for pyo3-branchwater: filename=pyo3_branchwater-0.8.2-cp312-cp312-macosx_10_7_x86_64.whl size=15361 sha256=0cdef7a6e9155c7e74a5592688d26862e86cac0374fa7d0b3ab793d1cafe5a6b
  Stored in directory: /private/var/folders/7z/r1593ybs1sj2ks5zzl9vy8840000gn/T/pip-ephem-wheel-cache-hks_uksm/wheels/fc/3d/e7/381bc5a98dadaf9e6cbc5306e5bf2044de82fd965c3457fa6e
Successfully built pyo3-branchwater
Installing collected packages: pyo3-branchwater
Successfully installed pyo3-branchwater-0.8.2
```